### PR TITLE
Added post on ELK integration

### DIFF
--- a/_posts/2021-08-11-elk-integration.md
+++ b/_posts/2021-08-11-elk-integration.md
@@ -9,7 +9,7 @@ author: Andreas Schade
 
 As of release [0.3.0-rc2](https://github.com/sysflow-telemetry/sf-processor/releases/tag/0.3.0-rc2)
 sf-processor can write SysFlow telemetry records to Elastic. To promote this new feature, we have
-created a [demonstrator](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integrations/elk that
+created a [demonstrator](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integrations/elk) that
 illustrates the integration of the [SysFlow Telemetry pipeline](https://sysflow.readthedocs.io/en/latest/)
 with ELK.
 
@@ -21,7 +21,7 @@ executes a set of commands belonging to the [Discovery](https://attack.mitre.org
 and [Command and Control](https://attack.mitre.org/tactics/TA0011/) techniques of the
 [MITRE ATT&CK&reg;](https://attack.mitre.org) framework.
 
-![Architecture of the demonstrator](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integrations/elk/images/pipeline.png?raw=true "Architecture of the demonstrator")
+![Architecture of the demonstrator](https://raw.githubusercontent.com/sysflow-telemetry/sf-deployments/dev/integrations/elk/images/pipeline.png ?raw=true "Architecture of the demonstrator")
 
 SysFlow collects the telemetry information created by the attack container. On this stream of raw events, SysFlow
 applies a custom processing pipeline that stores SysFlow data in two Elastic indices. One part of the pipeline
@@ -31,7 +31,7 @@ The second part of the pipeline stores the raw SysFlow events in a separate Elas
 investigation of alerts. The pipeline converts SysFlow alerts and raw SysFlow events to Elastic Common Schema
 before indexing them into ElasticSearch. The contents of both indices can be visualized using Kibana.
 
-![Kibana visualization of the alerts index](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integrations/elk/images/alerts.png?raw=true "Kibana visualization of the alerts index")
+![Kibana visualization of the alerts index](https://raw.githubusercontent.com/sysflow-telemetry/sf-deployments/dev/integrations/elk/images/alerts.png?raw=true "Kibana visualization of the alerts index")
 
 Check out our [SysFlow-ELK demonstrator](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integrations/elk)
 for instructions on running the code yourself, a description of the pipeline configuration and a detailed

--- a/_posts/2021-08-11-elk-integration.md
+++ b/_posts/2021-08-11-elk-integration.md
@@ -1,21 +1,19 @@
 ---
 layout: single
 title:  "SysFlow-ELK integration demonstrator"
-date:   2021-08-11 13:55:48 +0200
+date:   2021-08-20 13:55:48 +0200
 tags:   update
 author_profile: true
 author: Andreas Schade
 ---
 
-As of release [0.3.0-rc2](https://github.com/sysflow-telemetry/sf-processor/releases/tag/0.3.0-rc2)
-sf-processor can write SysFlow telemetry records to Elastic. To promote this new feature, we have
-created a [demonstrator](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integrations/elk) that
-illustrates the integration of the [SysFlow Telemetry pipeline](https://sysflow.readthedocs.io/en/latest/)
-with ELK.
+As of release [0.3.0-rc2](https://github.com/sysflow-telemetry/sf-processor/releases/tag/0.3.0-rc2),
+sf-processor can write SysFlow telemetry records to Elastic! 
 
-The setup of our demonstrator is based entirely on Docker. It uses the SysFlow docker deployment
-consisting of sf-collector and sf-processor containers and utilizes [Anthony Lapenna's](https://github.com/deviantony)
-[ELK Stack on Docker](https://github.com/deviantony/docker-elk/tree/tls) of which we deploy ELasticSearch
+To illustrate this new feature, we have created a [tutorial](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integrations/elk) 
+that showcases the integration of SysFlow with ELK. The setup is based entirely on Docker. It uses the SysFlow docker deployment
+consisting of sf-collector and sf-processor containers, and utilizes [Anthony Lapenna's](https://github.com/deviantony)
+[ELK Stack on Docker](https://github.com/deviantony/docker-elk/tree/tls) to deploy ElasticSearch
 to store and query SysFlow data and Kibana for visualisation. A fifth container acts as an attacker and
 executes a set of commands belonging to the [Discovery](https://attack.mitre.org/tactics/TA0007/)
 and [Command and Control](https://attack.mitre.org/tactics/TA0011/) techniques of the
@@ -25,17 +23,17 @@ and [Command and Control](https://attack.mitre.org/tactics/TA0011/) techniques o
 
 SysFlow collects the telemetry information created by the attack container. On this stream of raw events, SysFlow
 applies a custom processing pipeline that stores SysFlow data in two Elastic indices. One part of the pipeline
-uses rules for detecting potential use of MITRE ATT&CK&reg; techniques, generates alerts for matching SysFlow
+uses rules for detecting the potential use of MITRE ATT&CK&reg; techniques, generates alerts for matching SysFlow
 records, enriches them with the corresponding MITRE technique tags, and writes these alerts to an Elastic index.
 The second part of the pipeline stores the raw SysFlow events in a separate Elastic index for in-depth
-investigation of alerts. The pipeline converts SysFlow alerts and raw SysFlow events to Elastic Common Schema
+investigation of alerts. The pipeline converts SysFlow alerts and raw SysFlow events to [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html)
 before indexing them into ElasticSearch. The contents of both indices can be visualized using Kibana.
 
 ![Kibana visualization of the alerts index](https://raw.githubusercontent.com/sysflow-telemetry/sf-deployments/dev/integrations/elk/images/alerts.png?raw=true "Kibana visualization of the alerts index")
 
-Check out our [SysFlow-ELK demonstrator](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integrations/elk)
-for instructions on running the code yourself, a description of the pipeline configuration and a detailed
-explanation of the results!    
+Check this exciting new [integration](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integrations/elk)
+out for instructions on how to run the code yourself, a description of the pipeline configuration, and a detailed
+explanation of the results!
 
 
 

--- a/_posts/2021-08-11-elk-integration.md
+++ b/_posts/2021-08-11-elk-integration.md
@@ -9,7 +9,7 @@ author: Andreas Schade
 
 As of release [0.3.0-rc2](https://github.com/sysflow-telemetry/sf-processor/releases/tag/0.3.0-rc2)
 sf-processor can write SysFlow telemetry records to Elastic. To promote this new feature, we have
-created a [demonstrator](https://github.com/sysflow-telemetry/sf-deployments/integration/elk) that
+created a [demonstrator](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integration/elk) that
 illustrates the integration of the [SysFlow Telemetry pipeline](https://sysflow.readthedocs.io/en/latest/)
 with ELK.
 
@@ -21,7 +21,7 @@ executes a set of commands belonging to the [Discovery](https://attack.mitre.org
 and [Command and Control](https://attack.mitre.org/tactics/TA0011/) techniques of the
 [MITRE ATT&CK&reg;](https://attack.mitre.org) framework.
 
-![Architecture of the demonstrator](https://github.com/sysflow-telemetry/sf-deployments/integration/elk/images/pipeline.png?raw=true "Architecture of the demonstrator")
+![Architecture of the demonstrator](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integration/elk/images/pipeline.png?raw=true "Architecture of the demonstrator")
 
 SysFlow collects the telemetry information created by the attack container. On this stream of raw events, SysFlow
 applies a custom processing pipeline that stores SysFlow data in two Elastic indices. One part of the pipeline
@@ -31,9 +31,9 @@ The second part of the pipeline stores the raw SysFlow events in a separate Elas
 investigation of alerts. The pipeline converts SysFlow alerts and raw SysFlow events to Elastic Common Schema
 before indexing them into ElasticSearch. The contents of both indices can be visualized using Kibana.
 
-![Kibana visualization of the alerts index](https://github.com/sysflow-telemetry/sf-deployments/integration/elk/images/alerts.png?raw=true "Kibana visualization of the alerts index")
+![Kibana visualization of the alerts index](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integration/elk/images/alerts.png?raw=true "Kibana visualization of the alerts index")
 
-Check out our [SysFlow-ELK demonstrator](https://github.com/sysflow-telemetry/sf-deployments/integration/elk)
+Check out our [SysFlow-ELK demonstrator](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integration/elk)
 for instructions on running the code yourself, a description of the pipeline configuration and a detailed
 explanation of the results!    
 

--- a/_posts/2021-08-11-elk-integration.md
+++ b/_posts/2021-08-11-elk-integration.md
@@ -21,7 +21,7 @@ executes a set of commands belonging to the [Discovery](https://attack.mitre.org
 and [Command and Control](https://attack.mitre.org/tactics/TA0011/) techniques of the
 [MITRE ATT&CK&reg;](https://attack.mitre.org) framework.
 
-![Architecture of the demonstrator](https://raw.githubusercontent.com/sysflow-telemetry/sf-deployments/dev/integrations/elk/images/pipeline.png ?raw=true "Architecture of the demonstrator")
+![Architecture of the demonstrator](https://raw.githubusercontent.com/sysflow-telemetry/sf-deployments/dev/integrations/elk/images/pipeline.png?raw=true "Architecture of the demonstrator")
 
 SysFlow collects the telemetry information created by the attack container. On this stream of raw events, SysFlow
 applies a custom processing pipeline that stores SysFlow data in two Elastic indices. One part of the pipeline

--- a/_posts/2021-08-11-elk-integration.md
+++ b/_posts/2021-08-11-elk-integration.md
@@ -1,0 +1,42 @@
+---
+layout: single
+title:  "SysFlow-ELK integration demonstrator"
+date:   2021-08-11 13:55:48 +0200
+tags:   update
+author_profile: true
+author: Andreas Schade
+---
+
+As of release [0.3.0-rc2](https://github.com/sysflow-telemetry/sf-processor/releases/tag/0.3.0-rc2)
+sf-processor can write SysFlow telemetry records to Elastic. To promote this new feature, we have
+created a [demonstrator](https://github.com/sysflow-telemetry/sf-deployments/integration/elk) that
+illustrates the integration of the [SysFlow Telemetry pipeline](https://sysflow.readthedocs.io/en/latest/)
+with ELK.
+
+The setup of our demonstrator is based entirely on Docker. It uses the SysFlow docker deployment
+consisting of sf-collector and sf-processor containers and utilizes [Anthony Lapenna's](https://github.com/deviantony)
+[ELK Stack on Docker](https://github.com/deviantony/docker-elk/tree/tls) of which we deploy ELasticSearch
+to store and query SysFlow data and Kibana for visualisation. A fifth container acts as an attacker and
+executes a set of commands belonging to the [Discovery](https://attack.mitre.org/tactics/TA0007/)
+and [Command and Control](https://attack.mitre.org/tactics/TA0011/) techniques of the
+[MITRE ATT&CK&reg;](https://attack.mitre.org) framework.
+
+![Architecture of the demonstrator](https://github.com/sysflow-telemetry/sf-deployments/integration/elk/images/pipeline.png?raw=true "Architecture of the demonstrator")
+
+SysFlow collects the telemetry information created by the attack container. On this stream of raw events, SysFlow
+applies a custom processing pipeline that stores SysFlow data in two Elastic indices. One part of the pipeline
+uses rules for detecting potential use of MITRE ATT&CK&reg; techniques, generates alerts for matching SysFlow
+records, enriches them with the corresponding MITRE technique tags, and writes these alerts to an Elastic index.
+The second part of the pipeline stores the raw SysFlow events in a separate Elastic index for in-depth
+investigation of alerts. The pipeline converts SysFlow alerts and raw SysFlow events to Elastic Common Schema
+before indexing them into ElasticSearch. The contents of both indices can be visualized using Kibana.
+
+![Kibana visualization of the alerts index](https://github.com/sysflow-telemetry/sf-deployments/integration/elk/images/alerts.png?raw=true "Kibana visualization of the alerts index")
+
+Check out our [SysFlow-ELK demonstrator](https://github.com/sysflow-telemetry/sf-deployments/integration/elk)
+for instructions on running the code yourself, a description of the pipeline configuration and a detailed
+explanation of the results!    
+
+
+
+

--- a/_posts/2021-08-11-elk-integration.md
+++ b/_posts/2021-08-11-elk-integration.md
@@ -9,7 +9,7 @@ author: Andreas Schade
 
 As of release [0.3.0-rc2](https://github.com/sysflow-telemetry/sf-processor/releases/tag/0.3.0-rc2)
 sf-processor can write SysFlow telemetry records to Elastic. To promote this new feature, we have
-created a [demonstrator](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integration/elk) that
+created a [demonstrator](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integrations/elk that
 illustrates the integration of the [SysFlow Telemetry pipeline](https://sysflow.readthedocs.io/en/latest/)
 with ELK.
 
@@ -21,7 +21,7 @@ executes a set of commands belonging to the [Discovery](https://attack.mitre.org
 and [Command and Control](https://attack.mitre.org/tactics/TA0011/) techniques of the
 [MITRE ATT&CK&reg;](https://attack.mitre.org) framework.
 
-![Architecture of the demonstrator](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integration/elk/images/pipeline.png?raw=true "Architecture of the demonstrator")
+![Architecture of the demonstrator](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integrations/elk/images/pipeline.png?raw=true "Architecture of the demonstrator")
 
 SysFlow collects the telemetry information created by the attack container. On this stream of raw events, SysFlow
 applies a custom processing pipeline that stores SysFlow data in two Elastic indices. One part of the pipeline
@@ -31,9 +31,9 @@ The second part of the pipeline stores the raw SysFlow events in a separate Elas
 investigation of alerts. The pipeline converts SysFlow alerts and raw SysFlow events to Elastic Common Schema
 before indexing them into ElasticSearch. The contents of both indices can be visualized using Kibana.
 
-![Kibana visualization of the alerts index](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integration/elk/images/alerts.png?raw=true "Kibana visualization of the alerts index")
+![Kibana visualization of the alerts index](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integrations/elk/images/alerts.png?raw=true "Kibana visualization of the alerts index")
 
-Check out our [SysFlow-ELK demonstrator](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integration/elk)
+Check out our [SysFlow-ELK demonstrator](https://github.com/sysflow-telemetry/sf-deployments/tree/dev/integrations/elk)
 for instructions on running the code yourself, a description of the pipeline configuration and a detailed
 explanation of the results!    
 


### PR DESCRIPTION
New post that introduces and links to the ELK integration demonstrator in the `dev` branch of `sf-deployments`. 